### PR TITLE
Fix emulator modals

### DIFF
--- a/components/modals/EmulatorWindows.tsx
+++ b/components/modals/EmulatorWindows.tsx
@@ -3,25 +3,71 @@ import React from 'react';
 interface EmulatorWindowProps {
   src: string;
   title: string;
+  isVisible: boolean;
+  onClose: () => void;
 }
 
-const EmulatorWindow: React.FC<EmulatorWindowProps> = ({ src, title }) => {
+const EmulatorWindow: React.FC<EmulatorWindowProps> = ({ src, title, isVisible, onClose }) => {
+  if (!isVisible) {
+    return null;
+  }
+
   return (
-    <div style={{ width: '100%', height: '100vh', display: 'flex', flexDirection: 'column' }}>
-      <h2>{title}</h2>
-      <iframe
-        src={src}
-        style={{ width: '100%', height: '100%', border: 'none' }}
-        title={title}
-      />
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000,
+    }}>
+      <div style={{
+        width: '80%',
+        height: '80%',
+        backgroundColor: '#1e1e1e',
+        padding: '20px',
+        borderRadius: '8px',
+        display: 'flex',
+        flexDirection: 'column',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+          <h2 style={{ color: '#d4d4d4', margin: 0 }}>{title}</h2>
+          <button onClick={onClose} style={{
+            background: '#3c3c3c',
+            border: '1px solid #555',
+            color: '#ccc',
+            padding: '5px 10px',
+            borderRadius: '4px',
+            cursor: 'pointer',
+          }}>Close</button>
+        </div>
+        <iframe
+          src={src}
+          style={{ width: '100%', height: 'calc(100% - 40px)', border: '1px solid #333' }}
+          title={title}
+        />
+      </div>
     </div>
   );
 };
 
-export const SectorforthEmulatorWindow: React.FC = () => {
-  return <EmulatorWindow src="/public/start-sectorforth.html" title="Sectorforth Emulator" />;
+interface EmulatorProps {
+  isVisible: boolean;
+  src: string;
+  onClose: () => void;
+  onCopy: (text: string) => void;
+  copiedContent: string;
+  title?: string;
+}
+
+export const SectorforthEmulatorWindow: React.FC<EmulatorProps> = (props) => {
+  return <EmulatorWindow {...props} title="Sectorforth Emulator" />;
 };
 
-export const GenericEmulatorWindow: React.FC = () => {
-  return <EmulatorWindow src="/public/start-freedos.html" title="FreeDOS Emulator" />;
+export const GenericEmulatorWindow: React.FC<EmulatorProps> = (props) => {
+  return <EmulatorWindow {...props} title={props.title || "Emulator"} />;
 };

--- a/index.html
+++ b/index.html
@@ -29,10 +29,6 @@
 <link rel="stylesheet" href="/index.css">
 </head>
   <body>
-    <div>
-      <a href="/public/start-freedos.html" target="_blank">FreeDOS Emulator</a>
-      <a href="/public/start-sectorforth.html" target="_blank">Sectorforth Emulator</a>
-    </div>
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
 </body>

--- a/public/start-sectorforth.html
+++ b/public/start-sectorforth.html
@@ -231,43 +231,43 @@
                 <p>Paste these definitions into the emulator to build up functionality.</p>
                 
                 <div class="command-item">
-                    <h4>DUP <span class="stack-effect">( x -- x x )</span></h4>
-                    <div class="code-block"><code>: DUP SP@ @ ;</code><button class="copy-btn" onclick="copyText(this, ': DUP SP@ @ ;')">Copy</button></div>
+                    <h4><button class="copy-btn" onclick="copyText(this, ': DUP SP@ @ ;')">Copy</button>DUP <span class="stack-effect">( x -- x x )</span></h4>
+                    <p><code>: DUP SP@ @ ;</code></p>
                 </div>
                 
                 <div class="command-item">
-                    <h4>INVERT <span class="stack-effect">( x -- !x )</span></h4>
-                    <div class="code-block"><code>: INVERT DUP NAND ;</code><button class="copy-btn" onclick="copyText(this, ': INVERT DUP NAND ;')">Copy</button></div>
+                    <h4><button class="copy-btn" onclick="copyText(this, ': INVERT DUP NAND ;')">Copy</button>INVERT <span class="stack-effect">( x -- !x )</span></h4>
+                    <p><code>: INVERT DUP NAND ;</code></p>
                 </div>
 
                 <div class="command-item">
-                    <h4>-1 and 1</h4>
-                    <div class="code-block"><code>: -1 0 INVERT ;\n: 1 -1 DUP + INVERT ;</code><button class="copy-btn" onclick="copyText(this, ': -1 0 INVERT ;\\n: 1 -1 DUP + INVERT ;')">Copy</button></div>
+                    <h4><button class="copy-btn" onclick="copyText(this, ': -1 0 INVERT ;\\n: 1 -1 DUP + INVERT ;')">Copy</button>-1 and 1</h4>
+                    <p><code>: -1 0 INVERT ;</code><br><code>: 1 -1 DUP + INVERT ;</code></p>
                 </div>
 
                 <div class="command-item">
-                    <h4>NEGATE <span class="stack-effect">( x -- -x )</span></h4>
-                    <div class="code-block"><code>: NEGATE INVERT 1 + ;</code><button class="copy-btn" onclick="copyText(this, ': NEGATE INVERT 1 + ;')">Copy</button></div>
+                    <h4><button class="copy-btn" onclick="copyText(this, ': NEGATE INVERT 1 + ;')">Copy</button>NEGATE <span class="stack-effect">( x -- -x )</span></h4>
+                    <p><code>: NEGATE INVERT 1 + ;</code></p>
                 </div>
 
                 <div class="command-item">
-                    <h4>Numbers 2 to 6</h4>
-                    <div class="code-block"><code>: 2 1 1 + ;\n: 3 1 2 + ;\n: 4 2 2 + ;\n: 5 2 3 + ;\n: 6 3 3 + ;</code><button class="copy-btn" onclick="copyText(this, ': 2 1 1 + ;\\n: 3 1 2 + ;\\n: 4 2 2 + ;\\n: 5 2 3 + ;\\n: 6 3 3 + ;')">Copy</button></div>
+                    <h4><button class="copy-btn" onclick="copyText(this, ': 2 1 1 + ;\\n: 3 1 2 + ;\\n: 4 2 2 + ;\\n: 5 2 3 + ;\\n: 6 3 3 + ;')">Copy</button>Numbers 2 to 6</h4>
+                    <p><code>: 2 1 1 + ;</code><br><code>: 3 1 2 + ;</code><br><code>: 4 2 2 + ;</code><br><code>: 5 2 3 + ;</code><br><code>: 6 3 3 + ;</code></p>
                 </div>
 
                 <div class="command-item">
-                    <h4>OVER <span class="stack-effect">( x y -- x y x )</span></h4>
-                    <div class="code-block"><code>: OVER SP@ 2 + @ ;</code><button class="copy-btn" onclick="copyText(this, ': OVER SP@ 2 + @ ;')">Copy</button></div>
+                    <h4><button class="copy-btn" onclick="copyText(this, ': OVER SP@ 2 + @ ;')">Copy</button>OVER <span class="stack-effect">( x y -- x y x )</span></h4>
+                    <p><code>: OVER SP@ 2 + @ ;</code></p>
                 </div>
                 
                 <div class="command-item">
-                    <h4>DROP <span class="stack-effect">( x -- )</span></h4>
-                    <div class="code-block"><code>: DROP SP@ 2 + SP@ ! ;</code><button class="copy-btn" onclick="copyText(this, ': DROP SP@ 2 + SP@ ! ;')">Copy</button></div>
+                    <h4><button class="copy-btn" onclick="copyText(this, ': DROP SP@ 2 + SP@ ! ;')">Copy</button>DROP <span class="stack-effect">( x -- )</span></h4>
+                    <p><code>: DROP SP@ 2 + SP@ ! ;</code></p>
                 </div>
 
                 <div class="command-item">
-                    <h4>SWAP <span class="stack-effect">( x y -- y x )</span></h4>
-                    <div class="code-block"><code>: SWAP OVER OVER SP@ 6 + ! SP@ 2 + ! ;</code><button class="copy-btn" onclick="copyText(this, ': SWAP OVER OVER SP@ 6 + ! SP@ 2 + ! ;')">Copy</button></div>
+                    <h4><button class="copy-btn" onclick="copyText(this, ': SWAP OVER OVER SP@ 6 + ! SP@ 2 + ! ;')">Copy</button>SWAP <span class="stack-effect">( x y -- y x )</span></h4>
+                    <p><code>: SWAP OVER OVER SP@ 6 + ! SP@ 2 + ! ;</code></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Reverted changes to `index.html` to remove direct links.
- Updated styling for Sectorforth help section in `public/start-sectorforth.html`.
- Updated `components/modals/EmulatorWindows.tsx` to render emulators in modals.
- Verified state variables and modal opening logic in `index.tsx`.