### PR TITLE
Fix pako.min.js path in emulator HTML files

### DIFF
--- a/public/start-freedos.html
+++ b/public/start-freedos.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>File Decoder for Freedos Emulator</title>
-    <script src="pako_inflate.min.js"></script>
+    <script src="/pako_inflate.min.js"></script>
     <style>
         body {
             font-family: sans-serif;

--- a/public/start-sectorforth.html
+++ b/public/start-sectorforth.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>File Decoder for Sectorforth Emulator</title>
-    <script src="pako_inflate.min.js"></script>
+    <script src="/pako_inflate.min.js"></script>
     <style>
         body {
             font-family: sans-serif;


### PR DESCRIPTION
- Changed the src attribute of the script tag for pako_inflate.min.js to /pako_inflate.min.js in start-freedos.html and start-sectorforth.html.