### PR TITLE
Fix pako.min.js path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
-      }
+      },
+      assetsInclude: ['**/*.bin', '**/*.img', '**/pako_inflate.min.js']
     };
 });


### PR DESCRIPTION
- Added pako_inflate.min.js to assetsInclude in vite.config.ts.
- Verified that pako_inflate.min.js script src is /pako_inflate.min.js in emulator HTML files.