### PR TITLE
Add console logging for unpacked files

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -328,6 +328,7 @@ Analyze the user's request and the selected operator, and generate the appropria
         setLoading(true);
         setError(null);
         const unpackedFiles = await unpackFiles();
+        console.log('Unpacked files from unpackFiles():', JSON.stringify(unpackedFiles.map(f => ({ name: f.name, type: f.type, size: f.size, url: f.url })), null, 2));
         setFiles(unpackedFiles);
 
         const defaultActiveFile = unpackedFiles.find(f => f.name === 'LIA_HOSS.key') || unpackedFiles[0];


### PR DESCRIPTION
To debug why emulator asset maps are empty, this commit adds a console.log in `index.tsx` to output the list of files and their details immediately after `unpackFiles()` is called. This will help verify the names and presence of assets expected by the emulators.